### PR TITLE
Remove test from email subject

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -46,7 +46,15 @@ export async function POST(request: Request) {
 
     // Sanitize inputs
     const sanitizedEmail = email.trim().toLowerCase();
-    const sanitizedSubject = subject.trim().substring(0, 200); // Limit subject length
+    let sanitizedSubject = subject.trim().substring(0, 200); // Limit subject length
+    sanitizedSubject = sanitizedSubject
+      .replace(/\btest\b/gi, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+
+    if (!sanitizedSubject) {
+      sanitizedSubject = 'Support request';
+    }
     const sanitizedMessage = message.trim().substring(0, 5000); // Limit message length
 
     // Check if Gmail is configured

--- a/app/api/lib/rateLimit.ts
+++ b/app/api/lib/rateLimit.ts
@@ -72,6 +72,7 @@ export function recordError(identifier: string): { shouldTimeout: boolean; timeo
       errorCount: 0,
       resetTime: 0,
       lastErrorTime: 0,
+      timeoutLevel: 0,
     };
   }
 
@@ -147,6 +148,7 @@ export function rateLimit(
       errorCount: 0,
       resetTime: now + windowMs,
       lastErrorTime: 0,
+      timeoutLevel: 0,
     };
   }
 


### PR DESCRIPTION
Remove the word "test" from email subjects and improve subject sanitization.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c006197-b03b-4f23-8f74-23120dc2cfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c006197-b03b-4f23-8f74-23120dc2cfc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

